### PR TITLE
move import of docutils to a later point in time

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -12,10 +12,6 @@
 
 from SublimeLinter.lint import highlight, Linter
 
-import docutils
-from docutils.nodes import Element
-from docutils.parsers.rst import Parser
-
 
 class Rst(Linter):
 
@@ -26,6 +22,10 @@ class Rst(Linter):
 
     def run(self, cmd, code):
         """Attempt to parse code as reStructuredText."""
+        import docutils
+        from docutils.nodes import Element
+        from docutils.parsers.rst import Parser
+
         # Generate a new parser
         parser = Parser()
 


### PR DESCRIPTION
As mentioned in #1 `docutils` should not be imported at load time since the Python path is not yet setup. By moving the import into the run function allows it to be found.

On a clean installation with `python3-docutils` being installed the plugin is currently not being able to import `docutils`. With this patch it works.
